### PR TITLE
Added Auto Camera rotation field on Template Loader

### DIFF
--- a/Editor/Drawers/AttributeDrawers/ShowIfAttributeDrawer.cs
+++ b/Editor/Drawers/AttributeDrawers/ShowIfAttributeDrawer.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+using UnityEditor;
+
+namespace Treasured.UnitySdk
+{
+    [CustomPropertyDrawer(typeof(ShowIfAttribute))]
+    public class ShowIfAttributeDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            ShowIfAttribute attribute = (ShowIfAttribute)base.attribute;
+            var canEnable = GetShowIfResult(attribute, property);
+            var wasEnabled = GUI.enabled;
+            GUI.enabled = canEnable;
+
+            if (canEnable)
+            {
+                EditorGUI.PropertyField(position, property, label, true);
+            }
+
+            GUI.enabled = wasEnabled;
+        }
+
+        private bool GetShowIfResult(ShowIfAttribute attribute, SerializedProperty property)
+        {
+            var canEnable = true;
+
+            if (string.IsNullOrWhiteSpace(attribute.ValueToCompare))
+                return canEnable;
+
+            var propertyPath = property.propertyPath;
+            var conditionPath = propertyPath.Replace(property.name, attribute.ConditionalField);
+            var sourcePropertyValue = property.serializedObject.FindProperty(conditionPath);
+
+            if (sourcePropertyValue != null)
+            {
+                return sourcePropertyValue.stringValue == attribute.ValueToCompare;
+            }
+            else
+            {
+                Debug.LogWarning("Attempting to use a ConditionalHideAttribute but no matching SourcePropertyValue found in object: " + attribute.ConditionalField);
+            }
+
+            return canEnable;
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            ShowIfAttribute condHAtt = (ShowIfAttribute)attribute;
+            var enabled = GetShowIfResult(condHAtt, property);
+
+            if (enabled)
+            {
+                return EditorGUI.GetPropertyHeight(property, label);
+            }
+            else
+            {
+                return -EditorGUIUtility.standardVerticalSpacing;
+            }
+        }
+    }
+}

--- a/Editor/Drawers/AttributeDrawers/ShowIfAttributeDrawer.cs.meta
+++ b/Editor/Drawers/AttributeDrawers/ShowIfAttributeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8495fb863ab3ee342b1162238465fc91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Attributes/ShowIfAttribute.cs
+++ b/Runtime/Attributes/ShowIfAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+using UnityEngine;
+
+namespace Treasured.UnitySdk
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property |
+        AttributeTargets.Class | AttributeTargets.Struct, Inherited = true)]
+    public class ShowIfAttribute : PropertyAttribute
+    {
+        public string ConditionalField = "";
+        public string ValueToCompare = "";
+
+        /// <summary>
+        /// Show the field if the string field matches with the provided condition
+        /// </summary>
+        /// <param name="conditionalField">The name of the string field that will be in control</param>
+        /// <param name="valueToCompare">Compare with the string value</param>
+        public ShowIfAttribute(string conditionalField, string valueToCompare)
+        {
+            this.ConditionalField = conditionalField.ToLower();
+            this.ValueToCompare = valueToCompare.ToLower();
+        }
+    }
+}

--- a/Runtime/Attributes/ShowIfAttribute.cs.meta
+++ b/Runtime/Attributes/ShowIfAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88da2fdd922eb4149b0ccaf31eb61a54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Component/TreasuredMap.cs
+++ b/Runtime/Component/TreasuredMap.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using UnityEngine;
 
@@ -100,5 +100,14 @@ namespace Treasured.UnitySdk
         [SerializeField]
         private int _interactableLayer; // game object can only have one layer thus using int instead of LayerMask
         #endregion
+
+        private void OnValidate()
+        {
+            //  Set default Auto Camera Rotation to false for all except for modern loader template 
+            if (_templateLoader.template != "modern")
+            {
+                _templateLoader.autoCameraRotation = false;
+            }
+        }
     }
 }

--- a/Runtime/Data/TemplateLoader.cs
+++ b/Runtime/Data/TemplateLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 namespace Treasured.UnitySdk
@@ -8,6 +8,10 @@ namespace Treasured.UnitySdk
     {
         [Preset("simple", "standard", "modern")]
         public string template;
+
+        [ShowIf("template", "modern")]
+        public bool autoCameraRotation;
+
         [TextArea(3, 3)]
         public string imageUrl;
     }


### PR DESCRIPTION
- `AutoCamerRotation` field will only be displayed when the template loader is `modern`
- Default value for `AutoCamerRotation` will be false for all the template loaders except for `modern`
- Added `ShowIf` attribute to display attribute based on string comparison check condition