### PR TITLE
Fix path separators to be OS-agnostic

### DIFF
--- a/Runtime/Exporters/CubemapExporter.cs
+++ b/Runtime/Exporters/CubemapExporter.cs
@@ -108,7 +108,7 @@ namespace Treasured.UnitySdk
                     {
                         throw new System.NotSupportedException("Current graphic device/platform does not support RenderToCubemap.");
                     }
-                    var path = Directory.CreateDirectory(Path.Combine(Map.exportSettings.OutputDirectory, "images", exportAllQualities ? imageQuality.ToString().ToLower() : "", current.Id).Replace('/', '\\'));
+                    var path = Directory.CreateDirectory(Path.Combine(Map.exportSettings.OutputDirectory, "images", exportAllQualities ? imageQuality.ToString().ToLower() : "", current.Id).Replace('/', Path.DirectorySeparatorChar));
                     switch (cubemapFormat)
                     {
                         case CubemapFormat._3x2:

--- a/Runtime/Exporters/JsonExporter.cs
+++ b/Runtime/Exporters/JsonExporter.cs
@@ -25,7 +25,7 @@ namespace Treasured.UnitySdk
 
         public override void Export()
         {
-            string jsonPath = Path.Combine(Map.exportSettings?.OutputDirectory, "data.json").Replace('/', '\\');
+            string jsonPath = Path.Combine(Map.exportSettings?.OutputDirectory, "data.json").Replace('/', Path.DirectorySeparatorChar);
             string json = JsonConvert.SerializeObject(Map, formatting, JsonSettings);
             File.WriteAllText(jsonPath, json);
         }


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/system.io.path.directoryseparatorchar?view=net-6.0