### PR TITLE
fix: use EditorUtility.RevealInFinder to open file explorer

### DIFF
--- a/Editor/TreasuredMapEditor.cs
+++ b/Editor/TreasuredMapEditor.cs
@@ -328,7 +328,7 @@ namespace Treasured.UnitySdk
                 {
                     if (GUILayout.Button(EditorGUIUtility.TrIconContent("FolderOpened On Icon", "Open the current output folder in the File Explorer. This function is enabled when the directory exist."), Styles.exportButton, GUILayout.MaxWidth(24)))
                     {
-                        Application.OpenURL(_map.exportSettings.OutputDirectory);
+                        EditorUtility.RevealInFinder(_map.exportSettings.OutputDirectory);
                     }
                 }
                 if (GUILayout.Button(EditorGUIUtility.TrIconContent("icon dropdown"), Styles.exportButton, GUILayout.MaxWidth(24)))
@@ -338,7 +338,7 @@ namespace Treasured.UnitySdk
                     {
                         if (Directory.Exists(TreasuredSDKPreferences.Instance.customExportFolder))
                         {
-                            Application.OpenURL(TreasuredSDKPreferences.Instance.customExportFolder);
+                            EditorUtility.RevealInFinder(TreasuredSDKPreferences.Instance.customExportFolder);
                         }
                         else
                         {


### PR DESCRIPTION
I've read that `Application.OpenUrl` is meant moreso for runtime use. While not documented, `EditorUtility.RevealInFinder` is more accurate to what we're trying to do here, namely open a file explorer. It should work across OSes despite the name referring to MacOS's Finder